### PR TITLE
Address DIGITAL-1156 - Resolve Indexing Issues

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,29 +18,5 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-gatsby-cloud`,
-    {
-      resolve: `gatsby-plugin-lunr`,
-      options: {
-        languages: [
-          {
-            name: 'en',
-          },
-        ],
-        fields: [
-          { name: 'label', store: true, attributes: { boost: 20 } },
-          { name: 'id', store: true },
-        ],
-        resolvers: {
-          Manifests: {
-            label: node => node.label.en[0],
-            id: node => node.id,
-          },
-        },
-        filename: 'searchIndex.json',
-        fetchOptions: {
-          credentials: 'same-origin',
-        },
-      },
-    },
   ],
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -121,6 +121,7 @@ const createIndex = async (manifestNodes, type, cache) => {
     this.ref(`id`)
     this.field(`label`, {boost: 20})
     this.field(`summary`)
+    this.pipeline.remove(lunr.stemmer)
 
     for (const node of manifestNodes) {
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -112,37 +112,36 @@ const createIndex = async (manifestNodes, type, cache) => {
   if (cached) {
     return cached
   }
-  const documents = []
+
   const store = {}
-  // iterate over all posts
-  for (const node of manifestNodes) {
 
-    const id = node.id
-    const label = node.label.en[0]
-
-    let summary = ''
-    if (node.summary.en) {
-      summary = node.summary.en[0]
-    }
-
-    documents.push({
-      id: id,
-      label: label,
-      summary: summary,
-    })
-    store[id] = {
-      label,
-      summary,
-      node
-    }
-  }
-
+  // build index from manifests
   const index = lunr(function() {
-    this.ref("id")
-    this.field("label", { boost: 2 })
-    this.field("summary")
-    for (const doc of documents) {
-      this.add(doc)
+
+    this.ref(`id`)
+    this.field(`label`, {boost: 20})
+    this.field(`summary`)
+
+    for (const node of manifestNodes) {
+
+      const id = node.id
+      const label = node.label.en[0]
+
+      let summary = ''
+      if (node.summary.en) {
+        summary = node.summary.en[0]
+      }
+
+      store[id] = {
+        label: label,
+        summary: summary
+      }
+
+      this.add({
+        id: id,
+        label: label,
+        summary: summary
+      })
     }
   })
 

--- a/src/components/search-results.js
+++ b/src/components/search-results.js
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { Link } from "gatsby"
 import { Index } from "lunr"
-import { getValue } from "../utilities/iiif"
 
 const SearchResults = ({ data, initialQuery = "" }) => {
 
@@ -36,7 +35,7 @@ const SearchResults = ({ data, initialQuery = "" }) => {
                 <Link to={result.slug}>
                   <header>{result.label || result.slug}</header>
                 </Link>
-                <p>{getValue(result.node.summary, "en")}</p>
+                <p>{result.summary}</p>
               </div>
             </article>
           )


### PR DESCRIPTION
https://jirautk.atlassian.net/browse/DIGITAL-1156

# What Does This Do
This pull request is mostly some cleanup of our Lunr index build logic with https://github.com/mathewjordan/canopy/commit/72754dc74869bab40b889734f813a2f87e1fe662 being the fix that addresses the problem not returning results for the string search on `Gary`. 

# How Does This Work
Lunr has some builtin defaults, including a stemmer that _smartly_ reduces words within strings down to their root word. For some reason **Gary** was being reduced to **gari**.  Disabling the stemmer is maybe not the best choice if we intended this project to scale in anyway, however, it does resolve the issue.

# Anything Else You Should Know

The codebase previously has a duplicate way of handling Lunr indexing which was sending the index to file as searchIndex.json in the `/public` directory. This was handled with a Gatsby plugin, which was fine, but not very customizable. This has been removed and the Lunr index is now added as a resolver in GraphQL.



