### PR TITLE
Address Digital-1183

### DIFF
--- a/src/components/canopy/Description.js
+++ b/src/components/canopy/Description.js
@@ -6,11 +6,20 @@ class Description extends Component {
   }
 
   componentDidMount () {
-    console.log(this.props)
+
   }
 
   handleMetadata () {
-    return this.props.node.label.en[0]
+    const metadata = this.props.node.metadata
+    let description = this
+    return (metadata.map(function(element){
+      return (
+        <div>
+          <dt>{description.getLabel(element.label)}</dt>
+          {description.getValues(element.value.en)}
+        </div>
+      )
+    }));
   }
 
   handleRequiredStatement () {
@@ -25,7 +34,12 @@ class Description extends Component {
   }
 
   getValues(multiple_values) {
-    return multiple_values.map()
+    console.log(multiple_values)
+    return multiple_values.map(function(value) {
+      return (
+        <dd>{value}</dd>
+      )
+    })
   }
 
   render() {

--- a/src/components/canopy/Description.js
+++ b/src/components/canopy/Description.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+
+class Description extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount () {
+    console.log(this.props)
+  }
+
+  handleMetadata () {
+    return this.props.node.label.en[0]
+  }
+
+  handleRequiredStatement () {
+    return (<div>
+      <dt>{this.props.node.requiredStatement.label.en[0]}</dt>
+      <dd>{this.props.node.requiredStatement.value.en[0]}</dd>
+    </div>)
+  }
+
+  getLabel (label) {
+    return label.en[0]
+  }
+
+  getValues(multiple_values) {
+    return multiple_values.map()
+  }
+
+  render() {
+
+    return (
+      <div>
+        {this.handleMetadata()}
+        {this.handleRequiredStatement()}
+      </div>
+    )
+  }
+}
+
+export default Description;

--- a/src/components/canopy/Description.js
+++ b/src/components/canopy/Description.js
@@ -5,19 +5,16 @@ class Description extends Component {
     super(props);
   }
 
-  componentDidMount () {
-
-  }
 
   handleMetadata () {
     const metadata = this.props.node.metadata
     let description = this
     return (metadata.map(function(element){
       return (
-        <div>
+        <>
           <dt>{description.getLabel(element.label)}</dt>
           {description.getValues(element.value.en)}
-        </div>
+        </>
       )
     }
     ));
@@ -25,10 +22,10 @@ class Description extends Component {
 
   handleRequiredStatement () {
     return (
-      <div>
+      <>
         <dt>{this.props.node.requiredStatement.label.en[0]}</dt>
         <dd>{this.props.node.requiredStatement.value.en[0]}</dd>
-      </div>
+      </>
     )
   }
 
@@ -37,18 +34,15 @@ class Description extends Component {
   }
 
   getValues(multiple_values) {
-    console.log(multiple_values)
     return multiple_values.map(function(value) {
-      return (
-        <dd>{value}</dd>
-      )
+      return <dd>{value}</dd>
     })
   }
 
   render() {
 
     return (
-      <dl>
+      <dl className="canopy-metadata">
         {this.handleMetadata()}
         {this.handleRequiredStatement()}
       </dl>

--- a/src/components/canopy/Description.js
+++ b/src/components/canopy/Description.js
@@ -19,14 +19,17 @@ class Description extends Component {
           {description.getValues(element.value.en)}
         </div>
       )
-    }));
+    }
+    ));
   }
 
   handleRequiredStatement () {
-    return (<div>
-      <dt>{this.props.node.requiredStatement.label.en[0]}</dt>
-      <dd>{this.props.node.requiredStatement.value.en[0]}</dd>
-    </div>)
+    return (
+      <div>
+        <dt>{this.props.node.requiredStatement.label.en[0]}</dt>
+        <dd>{this.props.node.requiredStatement.value.en[0]}</dd>
+      </div>
+    )
   }
 
   getLabel (label) {
@@ -45,10 +48,10 @@ class Description extends Component {
   render() {
 
     return (
-      <div>
+      <dl>
         {this.handleMetadata()}
         {this.handleRequiredStatement()}
-      </div>
+      </dl>
     )
   }
 }

--- a/src/components/canopy/Description.js
+++ b/src/components/canopy/Description.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import MetadataElement from "./MetadataElement"
 
 class Description extends Component {
   constructor(props) {
@@ -8,12 +9,12 @@ class Description extends Component {
 
   handleMetadata () {
     const metadata = this.props.node.metadata
-    let description = this
     return (metadata.map(function(element){
       return (
         <>
-          <dt>{description.getLabel(element.label)}</dt>
-          {description.getValues(element.value.en)}
+          <MetadataElement element={element}
+                           language='en'
+          />
         </>
       )
     }
@@ -23,20 +24,11 @@ class Description extends Component {
   handleRequiredStatement () {
     return (
       <>
-        <dt>{this.props.node.requiredStatement.label.en[0]}</dt>
-        <dd>{this.props.node.requiredStatement.value.en[0]}</dd>
+          <MetadataElement element={this.props.node.requiredStatement}
+                           language='en'
+          />
       </>
     )
-  }
-
-  getLabel (label) {
-    return label.en[0]
-  }
-
-  getValues(multiple_values) {
-    return multiple_values.map(function(value) {
-      return <dd>{value}</dd>
-    })
   }
 
   render() {

--- a/src/components/canopy/MetadataElement.js
+++ b/src/components/canopy/MetadataElement.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+
+class MetadataElement extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  parseElement () {
+    return(
+      <>
+        {this.getLabel(this.props.element.label)}
+        {this.getValues(this.props.element.value)}
+      </>
+    )
+  }
+
+  getLabel (label) {
+    return <dt>{label[this.props.language][0]}</dt>
+  }
+
+  getValues(multiple_values) {
+    return multiple_values[this.props.language].map(function(value) {
+      return <dd>{value}</dd>
+    })
+  }
+
+  render() {
+
+    return (
+      this.parseElement()
+    )
+  }
+}
+
+export default MetadataElement;

--- a/src/components/layout/details.js
+++ b/src/components/layout/details.js
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as Tabs from "@radix-ui/react-tabs"
 import { getValue } from "../../utilities/iiif"
+import Description from "../canopy/Description"
 
 
 const Details = ({ id, node }) => {
@@ -16,7 +17,7 @@ const Details = ({ id, node }) => {
           <Tabs.Trigger value="translation">Translation</Tabs.Trigger>
         </Tabs.List>
         <div className="canopy-tabs--content">
-          <Tabs.Content value="details">{getValue(summary, 'en')}</Tabs.Content>
+          <Tabs.Content value="details"><Description node={node}/></Tabs.Content>
           <Tabs.Content value="transcript">[full transcript]</Tabs.Content>
           <Tabs.Content value="translation">[translations?]</Tabs.Content>
         </div>

--- a/src/sass/canopy.scss
+++ b/src/sass/canopy.scss
@@ -14,6 +14,7 @@
 @import "components/tabs";
 @import "components/viewer";
 @import "components/navigator";
+@import "components/description";
 
 // layout
 @import "layout/header";

--- a/src/sass/components/_description.scss
+++ b/src/sass/components/_description.scss
@@ -1,3 +1,32 @@
 .canopy-metadata {
-  display: flex;
+  display:flex;
+  flex-wrap:wrap;
+  width:100%;
+
+  dt {
+    font-weight:bold;
+    width:33%;
+    padding-top:1em;
+  }
+
+  dd {
+    display:flex;
+    margin:0;
+    padding-top:1em;
+  }
+
+  dd + dd {
+    width:100%;
+    padding-top:0;
+  }
+
+  dt + dd:not(:nth-child(2)) {
+    width:66%;
+  }
+
+  dd + dd::before {
+    width:33%;
+    content:"";
+    padding-top:0
+  }
 }

--- a/src/sass/components/_description.scss
+++ b/src/sass/components/_description.scss
@@ -1,0 +1,3 @@
+.canopy-metadata {
+  display: flex;
+}

--- a/src/sass/components/_description.scss
+++ b/src/sass/components/_description.scss
@@ -1,32 +1,14 @@
-.canopy-metadata {
-  display:flex;
-  flex-wrap:wrap;
-  width:100%;
-
+dl.canopy-metadata {
   dt {
-    font-weight:bold;
-    width:33%;
-    padding-top:1em;
+    font-weight: 700;
+    margin-top: 1em;
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   dd {
-    display:flex;
-    margin:0;
-    padding-top:1em;
-  }
-
-  dd + dd {
-    width:100%;
-    padding-top:0;
-  }
-
-  dt + dd:not(:nth-child(2)) {
-    width:66%;
-  }
-
-  dd + dd::before {
-    width:33%;
-    content:"";
-    padding-top:0
+    margin: 0;
   }
 }

--- a/src/templates/manifest.js
+++ b/src/templates/manifest.js
@@ -92,6 +92,14 @@ export const manifestQuery = graphql`
               en
             }
           }
+          metadata {
+            label {
+              en
+            }
+            value {
+              en
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
[DIGITAL-1183](https://jirautk.atlassian.net/browse/DIGITAL-1183)

# What Does This Do

Adds metadata to the details section of the digital object view.

# How Does It Work

1. We add a query for metadata in the gatsby graphql query in manifest.js.
2. Define a MetadataElement component that takes a IIIF style element with a label and value array within a specific language and parses out the object into a `<dt/><dd/>`.
3. Define a Description component that parses IIIF metadata and required statements, passes each key, value like pair to MetadataElement, and ultimately renders everything in a `<dl/>`.
4. Call the Description component in the appropriate tab in details.js.
5. Add some minimal styling.

# Anything else I should know?

Yes.  I wrote MetadataElement.js in a specific way.  It expects an element and language prop.  I did this to not assume `en` in case we do something special with `es`, but it's quite possible this could be done different.  Right now, Description doesn't really take advantage of this, but let's discuss.

# Did you create a merge conflict?

Yes, but let's talk.

# Could the styling be better?

Absolutely.  Let's talk about this and what I should think about.