### PR TITLE
Address DIGITAL-1181

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node-sass": "^6.0.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
+    "react-device-detect": "^1.17.0",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-icons": "^4.2.0",

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -136,9 +136,14 @@ class Video extends Component {
   }
 
   handlePause = () => {
-    this.setState({
-      playing: false
-    })
+    let component = this
+    setTimeout(function() {
+      if (component.video.current.paused) {
+        component.setState({
+          playing: false
+        })
+      }
+    }, 200);
   }
 
   handleUpdate = (t) => {

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -74,7 +74,7 @@ class Video extends Component {
         currentTime: event.target.currentTime
       })
     };
-    if (!isSafari) {
+    if (!isSafari && this.state.format === 'audio/mpeg') {
       this.audioVisualizer(this.video.current);
     }
   }

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -1,6 +1,7 @@
 import React, { Component, createRef } from "react"
 import Track from "./Track"
 import { isSafari } from "react-device-detect";
+import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 
 class Video extends Component {
   constructor(props) {
@@ -140,6 +141,18 @@ class Video extends Component {
     }
   }
 
+  renderFigure = () => {
+    return (
+      <div className="canopy-accompanying-canvas">
+        <AspectRatio.Root ratio={1}>
+          <figure>
+            <img src=""/>
+          </figure>
+        </AspectRatio.Root>
+      </div>
+    )
+  }
+
   renderAudioVisualizer = () => {
     return (
       <canvas id="canopy-audio-visualizer"
@@ -147,6 +160,18 @@ class Video extends Component {
       </canvas>
     )
   }
+
+  renderBackground = (format) => {
+    if (format === 'audio/mpeg') {
+      return (
+        <div className="canopy-video-background">
+          {this.renderFigure()}
+          {this.renderAudioVisualizer()}
+        </div>
+      )
+    }
+  }
+
 
   componentDidMount () {
     this.parseItems()
@@ -170,7 +195,7 @@ class Video extends Component {
             {this.renderSource(source, format)}
             {this.renderTracks(tracks)}
           </video>
-          {this.renderAudioVisualizer(format)}
+          {this.renderBackground(format)}
         </div>
       )
 

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -3,6 +3,46 @@ import Track from "./Track"
 import { isSafari } from "react-device-detect";
 import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 
+const accompanyingCanvas = {
+  "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+  "type": "Canvas",
+  "label": {
+    "en": [
+      "First page of score for Gustav Mahler, Symphony No. 3"
+    ]
+  },
+  "height": 998,
+  "width": 772,
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page",
+      "type": "AnnotationPage",
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image",
+          "type": "Annotation",
+          "motivation": "painting",
+          "body": {
+            "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg",
+            "type": "Image",
+            "format": "image/jpeg",
+            "height": 998,
+            "width": 772,
+            "service": [
+              {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",
+                "type": "ImageService3",
+                "profile": "level1"
+              }
+            ]
+          },
+          "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying"
+        }
+      ]
+    }
+  ]
+}
+
 class Video extends Component {
   constructor(props) {
     super(props);
@@ -14,7 +54,8 @@ class Video extends Component {
       currentTime: 0,
       updateTime: null,
       updated: true,
-      playing: false
+      playing: false,
+      image: null
     }
 
     this.video = createRef()
@@ -43,7 +84,9 @@ class Video extends Component {
     let component = this;
 
     if (Array.isArray(this.props.items)) {
+
       const items = this.props.items[0].items[0].items;
+
       items.map(function(element) {
         if (element.motivation === 'painting') {
           component.setState({
@@ -64,6 +107,17 @@ class Video extends Component {
           });
         }
       });
+
+      if (accompanyingCanvas) {
+        const src = accompanyingCanvas.items[0].items[0].body.id
+        const alt = accompanyingCanvas.label.en[0]
+        component.setState({
+          image: {
+            src,
+            alt
+          }
+        });
+      }
     }
   }
 
@@ -148,16 +202,18 @@ class Video extends Component {
     }
   }
 
-  renderFigure = () => {
-    return (
-      <div className="canopy-accompanying-canvas">
-        <AspectRatio.Root ratio={1}>
-          <figure>
-            <img src=""/>
-          </figure>
-        </AspectRatio.Root>
-      </div>
-    )
+  renderFigure = (image) => {
+    if (image) {
+      return (
+        <div className="canopy-accompanying-canvas">
+          <AspectRatio.Root ratio={1}>
+            <figure>
+              <img src={image.src} alt={image.alt} />
+            </figure>
+          </AspectRatio.Root>
+        </div>
+      )
+    }
   }
 
   renderAudioVisualizer = () => {
@@ -168,11 +224,11 @@ class Video extends Component {
     )
   }
 
-  renderBackground = (format) => {
+  renderBackground = (format, image) => {
     if (format === 'audio/mpeg') {
       return (
         <div className="canopy-video-background">
-          {this.renderFigure()}
+          {this.renderFigure(image)}
           {this.renderAudioVisualizer()}
         </div>
       )
@@ -190,7 +246,7 @@ class Video extends Component {
 
   render() {
 
-    let {source, format, tracks, playing} = this.state
+    let {source, format, tracks, playing, image} = this.state
 
     let className = `canopy-video`
     if (playing) {
@@ -208,7 +264,7 @@ class Video extends Component {
             {this.renderSource(source, format)}
             {this.renderTracks(tracks)}
           </video>
-          {this.renderBackground(format)}
+          {this.renderBackground(format, image)}
         </div>
       )
 

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -13,7 +13,8 @@ class Video extends Component {
       tracks: [],
       currentTime: 0,
       updateTime: null,
-      updated: true
+      updated: true,
+      playing: false
     }
 
     this.video = createRef()
@@ -66,18 +67,24 @@ class Video extends Component {
     }
   }
 
-
   handlePlay = () => {
     let video = this.video.current
     video.ontimeupdate = (event) => {
       this.props.time(event.target.currentTime)
       this.setState({
-        currentTime: event.target.currentTime
+        currentTime: event.target.currentTime,
+        playing: true
       })
     };
     if (!isSafari && this.state.format === 'audio/mpeg') {
       this.audioVisualizer(this.video.current);
     }
+  }
+
+  handlePause = () => {
+    this.setState({
+      playing: false
+    })
   }
 
   handleUpdate = (t) => {
@@ -183,14 +190,20 @@ class Video extends Component {
 
   render() {
 
-    let {source, format, tracks} = this.state
+    let {source, format, tracks, playing} = this.state
+
+    let className = `canopy-video`
+    if (playing) {
+      className = `canopy-video canopy-video-active`
+    }
 
     if (source) {
       return (
-        <div className="canopy-video">
+        <div className={className}>
           <video controls
                  ref={this.video}
                  onPlay={this.handlePlay}
+                 onPause={this.handlePause}
                  crossOrigin="anonymous">
             {this.renderSource(source, format)}
             {this.renderTracks(tracks)}

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -23,7 +23,7 @@ const accompanyingCanvas = {
           "type": "Annotation",
           "motivation": "painting",
           "body": {
-            "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg",
+            "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/!300,300/0/default.jpg",
             "type": "Image",
             "format": "image/jpeg",
             "height": 998,

--- a/src/sass/global/_variables.scss
+++ b/src/sass/global/_variables.scss
@@ -4,6 +4,8 @@ Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 $serif: 'Halant', Georgia, serif;
 
 $primary: #313E48;
+$primaryMuted: #465866;
+
 $muted: #f1f0ef;
 $midtone: darken($muted, 10);
 $highlight: darken($muted, 25);
@@ -17,6 +19,9 @@ $accentMuted: desaturate(lighten($accent, 38.2), 38.2);
 
 $offwhite: #FAF9F9;
 
-$box-shadow: 4px 4px 8px rgba($primary, 0.15);
-$box-shadow-focus: 6px 6px 12px rgba($primary, 0.25);
-$box-shadow-slim: 2px 2px 5px rgba($primary, 0.15);
+
+$box-shadow-color: darken($primary, 10);
+
+$box-shadow: 4px 4px 8px rgba($box-shadow-color, 0.15);
+$box-shadow-focus: 6px 6px 12px rgba($box-shadow-color, 0.25);
+$box-shadow-slim: 2px 2px 5px rgba($box-shadow-color, 0.15);

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -60,7 +60,7 @@ article.canopy-manifest {
           width: 30%;
           position: absolute;
           right: calc(35%);
-          top: calc(4em);
+          top: 15%;
           transition: all 200ms ease-in-out;
 
           figure {
@@ -90,8 +90,8 @@ article.canopy-manifest {
 
       &-active .canopy-accompanying-canvas {
         width: 15%;
-        right: 2em;
-        top: 2em;
+        right: 1rem;
+        top: 1rem;
       }
     }
 

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -57,25 +57,26 @@ article.canopy-manifest {
 
 
         .canopy-accompanying-canvas {
-          width: 20%;
+          width: 30%;
           position: absolute;
-          right: 2em;
-          top: 2em;
+          right: calc(35%);
+          top: calc(4em);
+          transition: all 200ms ease-in-out;
 
           figure {
             background-color: rgba($primaryMuted, 0.85);
-            box-shadow: $box-shadow-slim;
-            border-radius: 3px;
+            box-shadow: $box-shadow;
+            border-radius: 5px;
             display: block;
             width: 100%;
             height: 100%;
             margin: 0;
 
             img {
-              background-color: white;
-              margin: 0.25rem;
-              width: calc(100% - 0.5rem);
-              height: calc(100% - 0.5rem);
+              border-radius: 5px;
+              overflow: hidden;
+              width: 100%;
+              height: 100%;
               object-fit: cover;
             }
           }
@@ -85,6 +86,12 @@ article.canopy-manifest {
           width: 100%;
           height: 100%;
         }
+      }
+
+      &-active .canopy-accompanying-canvas {
+        width: 15%;
+        right: 2em;
+        top: 2em;
       }
     }
 

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -45,7 +45,7 @@ article.canopy-manifest {
         z-index: 1;
       }
 
-      canvas {
+      &-background {
         position: absolute;
         padding: 0;
         margin: 0;
@@ -54,6 +54,37 @@ article.canopy-manifest {
         width: 100%;
         height: 100%;
         z-index: 0;
+
+
+        .canopy-accompanying-canvas {
+          width: 20%;
+          position: absolute;
+          right: 2em;
+          top: 2em;
+
+          figure {
+            background-color: rgba($primaryMuted, 0.85);
+            box-shadow: $box-shadow-slim;
+            border-radius: 3px;
+            display: block;
+            width: 100%;
+            height: 100%;
+            margin: 0;
+
+            img {
+              background-color: white;
+              margin: 0.25rem;
+              width: calc(100% - 0.5rem);
+              height: calc(100% - 0.5rem);
+              object-fit: cover;
+            }
+          }
+        }
+
+        canvas {
+          width: 100%;
+          height: 100%;
+        }
       }
     }
 

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -33,9 +33,28 @@ article.canopy-manifest {
       flex-grow: 1;
       flex-shrink: 1;
       width: 61.8%;
-      background-color: $secondaryMuted;
-      box-shadow: $box-shadow-slim;
+      background-color: $primary;
+      box-shadow: $box-shadow-focus;
       z-index: 1;
+
+      video {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        position: relative;
+        z-index: 1;
+      }
+
+      canvas {
+        position: absolute;
+        padding: 0;
+        margin: 0;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 0;
+      }
     }
 
     .canopy-navigator {

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -66,14 +66,12 @@ article.canopy-manifest {
           figure {
             background-color: rgba($primaryMuted, 0.85);
             box-shadow: $box-shadow;
-            border-radius: 5px;
             display: block;
             width: 100%;
             height: 100%;
             margin: 0;
 
             img {
-              border-radius: 5px;
               overflow: hidden;
               width: 100%;
               height: 100%;

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -65,7 +65,7 @@ article.canopy-manifest {
 
           figure {
             background-color: rgba($primaryMuted, 0.85);
-            box-shadow: $box-shadow;
+            box-shadow: $box-shadow-focus;
             display: block;
             width: 100%;
             height: 100%;
@@ -88,8 +88,8 @@ article.canopy-manifest {
 
       &-active .canopy-accompanying-canvas {
         width: 15%;
-        right: 1rem;
-        top: 1rem;
+        right: 2rem;
+        top: 2rem;
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11521,6 +11521,13 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
+react-device-detect@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.17.0.tgz#a00b4fd6880cebfab3fd8a42a79dc0290cdddca9"
+  integrity sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==
+  dependencies:
+    ua-parser-js "^0.7.24"
+
 react-dnd-html5-backend@^10.0.2:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-10.0.2.tgz#15cb9d2b923f43576a136df854e288cb5969784c"
@@ -13873,6 +13880,11 @@ typescript-tuple@^2.2.1:
   integrity sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==
   dependencies:
     typescript-compare "^0.0.2"
+
+ua-parser-js@^0.7.24:
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
https://jirautk.atlassian.net/browse/DIGITAL-1181

# What Does This Do
This pull request adds front end treatments to visual space occupied by the HTML5 video player when the source of that video is a format of audio. 

Included are:

- A flat image floating in the video space. Logic in Video.js leverages a IIIF **_accompanyingCanvas_** and parses out the URI of the image from the _body.id_, and gets the label of that canvas for an _alt_. When the audio is playing, the video shifts to upper right section of the video area.
- I also took the opportunity to build a simple audio visualizer that reads the buffer of the Audio and converts that data to vertical bars. This is out of scope but uses the space in a unique way. 

# What's next?
You'll see that include a sample **accompanyingCanvas** in [Video.js](https://github.com/utkdigitalinitiatives/canopy/pull/11/files#diff-e7be39e5234c90d5cb66150d23e736ea579d5fb85fe753ed2fa1473723088328R6-R44). Once we complete https://jirautk.atlassian.net/browse/DIGITAL-1181, some followup work will be required to gather this data from the manifest.

# Anything Else You Should Know
One issue I came across was that audio is not read the same in all browsers, and in Safari there is an issue related to [createMediaElementSource](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaElementSource). There may be workarounds for this, but I did not not attempt them. For this reason, I include a conditional not to render the audio visualizer in that browser.

