### PR TITLE
Address DIGITAL-1207 (Viewer Responsiveness)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-popover": "^0.0.20",
     "@radix-ui/react-tabs": "^0.0.15",
     "axios": "^0.21.1",
+    "body-scroll-lock": "^4.0.0-beta.0",
     "gatsby": "^3.6.2",
     "gatsby-plugin-gatsby-cloud": "^2.6.1",
     "gatsby-plugin-image": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "University of Tennessee Libraries",
   "dependencies": {
     "@radix-ui/react-aspect-ratio": "^0.0.14",
+    "@radix-ui/react-collapsible": "^0.0.17",
     "@radix-ui/react-dropdown-menu": "^0.0.22",
     "@radix-ui/react-id": "^0.0.6",
     "@radix-ui/react-popover": "^0.0.20",
@@ -32,6 +33,7 @@
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-icons": "^4.2.0",
+    "react-responsive": "^9.0.0-beta.3",
     "react-sticky-el": "^2.0.9",
     "striptags": "^3.2.0",
     "subtitles-parser-vtt": "^0.1.0"

--- a/src/components/canopy/DigitalObject.js
+++ b/src/components/canopy/DigitalObject.js
@@ -11,7 +11,8 @@ class DigitalObject extends Component {
     super(props);
 
     this.state = {
-      transcripts: []
+      transcripts: [],
+      mobileNavigatorStatus: false
     }
   }
 
@@ -47,6 +48,12 @@ class DigitalObject extends Component {
     return null
   }
 
+  mobileNavigatorStatus(value) {{
+    this.setState({
+      mobileNavigatorStatus: value
+    })
+  }}
+
   componentDidMount() {
     this.getTranscripts(this.props.node.transcripts)
   }
@@ -58,12 +65,15 @@ class DigitalObject extends Component {
 
     if (this.state.transcripts.length === this.props.node.transcripts.length) {
       return (
-        <article className="canopy-manifest">
+        <article className="canopy-manifest" data-mobile-navigator={this.state.mobileNavigatorStatus}>
           <Sticky className="canopy-sticky"
                   boundaryElement=".canopy-manifest">
             <DigitalObjectHeader title={label.en[0]}
                                  manifest={manifestId} />
-            <Viewer node={this.props.node} transcripts={this.state.transcripts} />
+            <Viewer node={this.props.node}
+                    transcripts={this.state.transcripts}
+                    mobileNavigatorStatus={this.mobileNavigatorStatus.bind(this)}
+            />
           </Sticky>
           <Details id={id}
                    node={node} />

--- a/src/components/canopy/Navigator.js
+++ b/src/components/canopy/Navigator.js
@@ -159,7 +159,7 @@ class Navigator extends Component {
 
   render() {
 
-    let {data, tabs, defaultOpen} = this.state
+    let {data, tabs} = this.state
     const {t} = this.props
 
     return (
@@ -174,7 +174,7 @@ class Navigator extends Component {
             </Collapsible.Content>
           </Collapsible.Root>
         </MediaQuery>
-        <MediaQuery minWidth={1025} onChange={this.handleMediaQueryChange}>
+        <MediaQuery minWidth={1025}>
           {this.renderNavigator(data, tabs, t)}
         </MediaQuery>
       </aside>

--- a/src/components/canopy/Navigator.js
+++ b/src/components/canopy/Navigator.js
@@ -164,7 +164,7 @@ class Navigator extends Component {
 
     return (
       <aside className="canopy-navigator">
-        <MediaQuery maxWidth={1024}>
+        <MediaQuery maxWidth={800}>
           <Collapsible.Root defaultOpen={false}>
             <Collapsible.Trigger>
               Expand
@@ -174,7 +174,7 @@ class Navigator extends Component {
             </Collapsible.Content>
           </Collapsible.Root>
         </MediaQuery>
-        <MediaQuery minWidth={1025}>
+        <MediaQuery minWidth={801}>
           {this.renderNavigator(data, tabs, t)}
         </MediaQuery>
       </aside>

--- a/src/components/canopy/Navigator.js
+++ b/src/components/canopy/Navigator.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import * as Tabs from "@radix-ui/react-tabs"
 import NavigatorPanel from "./NavigatorPanel"
-import MediaQuery from 'react-responsive'
-import * as Collapsible from '@radix-ui/react-collapsible';
 
 class Navigator extends Component {
   constructor(props) {
@@ -164,19 +162,7 @@ class Navigator extends Component {
 
     return (
       <aside className="canopy-navigator">
-        <MediaQuery maxWidth={800}>
-          <Collapsible.Root defaultOpen={false}>
-            <Collapsible.Trigger>
-              Expand
-            </Collapsible.Trigger>
-            <Collapsible.Content>
-              {this.renderNavigator(data, tabs, t)}
-            </Collapsible.Content>
-          </Collapsible.Root>
-        </MediaQuery>
-        <MediaQuery minWidth={801}>
-          {this.renderNavigator(data, tabs, t)}
-        </MediaQuery>
+        {this.renderNavigator(data, tabs, t)}
       </aside>
     )
   }

--- a/src/components/canopy/Navigator.js
+++ b/src/components/canopy/Navigator.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import * as Tabs from "@radix-ui/react-tabs"
 import NavigatorPanel from "./NavigatorPanel"
+import MediaQuery from 'react-responsive'
+import * as Collapsible from '@radix-ui/react-collapsible';
 
 class Navigator extends Component {
   constructor(props) {
@@ -9,7 +11,8 @@ class Navigator extends Component {
     this.state ={
       tabs: [],
       data: [],
-      loaded: false
+      loaded: false,
+      defaultOpen: false
     }
 
     this.updateTime = this.updateTime.bind(this);
@@ -31,7 +34,7 @@ class Navigator extends Component {
 
   buildTranscript = (iiif, transcript, translation) => {
     let component = this
-    
+
     let label = 'Transcript'
     if (translation && iiif.language === 'en') {
       label = "Translation"
@@ -156,12 +159,24 @@ class Navigator extends Component {
 
   render() {
 
-    let {data, tabs} = this.state
+    let {data, tabs, defaultOpen} = this.state
     const {t} = this.props
 
     return (
       <aside className="canopy-navigator">
-        {this.renderNavigator(data, tabs, t)}
+        <MediaQuery maxWidth={1024}>
+          <Collapsible.Root defaultOpen={false}>
+            <Collapsible.Trigger>
+              Expand
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              {this.renderNavigator(data, tabs, t)}
+            </Collapsible.Content>
+          </Collapsible.Root>
+        </MediaQuery>
+        <MediaQuery minWidth={1025} onChange={this.handleMediaQueryChange}>
+          {this.renderNavigator(data, tabs, t)}
+        </MediaQuery>
       </aside>
     )
   }

--- a/src/components/canopy/Navigator.js
+++ b/src/components/canopy/Navigator.js
@@ -127,6 +127,7 @@ class Navigator extends Component {
                           index={index}
                           updateTime={component.updateTime.bind(this)}
                           key={index}
+                          videoHeight={component.props.videoHeight}
           />
         </Tabs.Content>
       )

--- a/src/components/canopy/NavigatorPanel.js
+++ b/src/components/canopy/NavigatorPanel.js
@@ -89,10 +89,16 @@ class NavigatorPanel extends Component {
 
   render() {
 
-    const {data, time} = this.props
+    const {data, time, videoHeight} = this.props
+
+    let style = {height: `100%`}
+    if (videoHeight) {
+      style = {height: `calc(100% - ${videoHeight}px - 36px) `}
+    }
 
     return (
       <div ref={this.sequence}
+           style={style}
            className="canopy-sequence">
         {this.renderSequence(data.sequence, time)}
       </div>

--- a/src/components/canopy/NavigatorPanel.js
+++ b/src/components/canopy/NavigatorPanel.js
@@ -65,6 +65,9 @@ class NavigatorPanel extends Component {
     let activeItem = sequenceElement.querySelector(selector)
     if (activeItem.offsetParent) {
       let top = activeItem.offsetTop - activeItem.offsetParent.offsetTop
+      if (this.props.videoHeight) {
+        top = top + this.props.videoHeight + 36
+      }
       sequenceElement.scrollTo({
         top: top,
         left: 0,

--- a/src/components/canopy/Viewer.js
+++ b/src/components/canopy/Viewer.js
@@ -1,9 +1,11 @@
-import React, { Component, useRef } from 'react';
+import React, { Component, createRef, useRef } from "react"
 import PropTypes from "prop-types"
 import Navigator from "./Navigator"
 import Video from "./Video"
 import MediaQuery from 'react-responsive'
 import * as Collapsible from '@radix-ui/react-collapsible';
+import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
+
 
 class Viewer extends Component {
   constructor(props) {
@@ -11,10 +13,13 @@ class Viewer extends Component {
 
     this.state ={
       t: 0,
-      updateTime: null
+      updateTime: null,
+      mobileNavigatorStatus: false,
+      videoHeight: null
     }
 
     this.updateTime = this.updateTime.bind(this);
+    this.viewer = createRef()
   }
 
   time(value) {{
@@ -30,7 +35,18 @@ class Viewer extends Component {
   }
 
   handleCollapsible = (status) => {
-    console.log(status)
+    this.props.mobileNavigatorStatus(status)
+    if (status) {
+      disableBodyScroll('body');
+      this.setState({
+        videoHeight: this.viewer.current.children[0].clientHeight
+      })
+    } else {
+      enableBodyScroll('body');
+      this.setState({
+        videoHeight: null
+      })
+    }
   }
 
   handleMediaQuery = (status) => {
@@ -41,12 +57,16 @@ class Viewer extends Component {
     return null
   }
 
+  componentDidMount() {
+  }
+
   render() {
 
     const {id, manifestId, items, structures} = this.props.node;
 
     return (
-      <div className="canopy-viewer">
+      <div ref={this.viewer}
+           className="canopy-viewer">
         <Video items={items}
                time={this.time.bind(this)}
                updateTime={this.state.updateTime}
@@ -55,7 +75,8 @@ class Viewer extends Component {
           {(matches) => {
             if (matches) {
               return (
-                <Collapsible.Root defaultOpen={false}>
+                <Collapsible.Root defaultOpen={false}
+                                  onOpenChange={this.handleCollapsible}>
                   <Collapsible.Trigger  id="canopy-collapse-trigger-navigator"
                                         className="canopy-collapse-trigger">
                     <span>Show Active Context</span>
@@ -65,6 +86,7 @@ class Viewer extends Component {
                                transcripts={this.props.transcripts}
                                updateTime={this.updateTime.bind(this)}
                                structures={structures}
+                               videoHeight={this.state.videoHeight}
                     />
                   </Collapsible.Content>
                 </Collapsible.Root>

--- a/src/components/canopy/Viewer.js
+++ b/src/components/canopy/Viewer.js
@@ -5,6 +5,7 @@ import Video from "./Video"
 import MediaQuery from 'react-responsive'
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
+import * as Popover from "@radix-ui/react-popover"
 
 
 class Viewer extends Component {
@@ -80,6 +81,11 @@ class Viewer extends Component {
                   <Collapsible.Trigger  id="canopy-collapse-trigger-navigator"
                                         className="canopy-collapse-trigger">
                     <span>Show Active Context</span>
+                    <svg viewBox="0 0 32 32">
+                      <g transform="scale(1)">
+                        <path d="M21.443,10.584l-.027-.027a1.9,1.9,0,0,0-2.688,0L16,13.285l-2.728-2.728a1.9,1.9,0,0,0-2.688,0l-.027.027a1.9,1.9,0,0,0,0,2.688L13.285,16l-2.728,2.728a1.9,1.9,0,0,0,0,2.688l.027.027a1.9,1.9,0,0,0,2.688,0L16,18.715l2.728,2.728a1.9,1.9,0,0,0,2.688,0l.027-.027a1.9,1.9,0,0,0,0-2.688L18.715,16l2.728-2.728A1.9,1.9,0,0,0,21.443,10.584Z" />
+                      </g>
+                    </svg>
                   </Collapsible.Trigger>
                   <Collapsible.Content>
                     <Navigator t={this.state.t}

--- a/src/components/canopy/Viewer.js
+++ b/src/components/canopy/Viewer.js
@@ -51,7 +51,7 @@ class Viewer extends Component {
                time={this.time.bind(this)}
                updateTime={this.state.updateTime}
         />
-        <MediaQuery maxWidth={600}>
+        <MediaQuery maxWidth={800}>
           {(matches) => {
             if (matches) {
               return (

--- a/src/components/canopy/Viewer.js
+++ b/src/components/canopy/Viewer.js
@@ -51,7 +51,7 @@ class Viewer extends Component {
                time={this.time.bind(this)}
                updateTime={this.state.updateTime}
         />
-        <MediaQuery maxWidth={800}>
+        <MediaQuery maxWidth={600}>
           {(matches) => {
             if (matches) {
               return (

--- a/src/components/canopy/Viewer.js
+++ b/src/components/canopy/Viewer.js
@@ -2,6 +2,8 @@ import React, { Component, useRef } from 'react';
 import PropTypes from "prop-types"
 import Navigator from "./Navigator"
 import Video from "./Video"
+import MediaQuery from 'react-responsive'
+import * as Collapsible from '@radix-ui/react-collapsible';
 
 class Viewer extends Component {
   constructor(props) {
@@ -27,21 +29,57 @@ class Viewer extends Component {
     })
   }
 
+  handleCollapsible = (status) => {
+    console.log(status)
+  }
+
+  handleMediaQuery = (status) => {
+    // this.setState({
+    //   defaultOpen: status,
+    //   open: status
+    // })
+    return null
+  }
+
   render() {
 
     const {id, manifestId, items, structures} = this.props.node;
 
     return (
-        <div className="canopy-viewer">
-          <Video items={items}
-                 time={this.time.bind(this)}
-                 updateTime={this.state.updateTime}
-          />
-          <Navigator t={this.state.t}
-                     transcripts={this.props.transcripts}
-                     updateTime={this.updateTime.bind(this)}
-                     structures={structures} />
-        </div>
+      <div className="canopy-viewer">
+        <Video items={items}
+               time={this.time.bind(this)}
+               updateTime={this.state.updateTime}
+        />
+        <MediaQuery maxWidth={800}>
+          {(matches) => {
+            if (matches) {
+              return (
+                <Collapsible.Root defaultOpen={false}>
+                  <Collapsible.Trigger>
+                    Expand
+                  </Collapsible.Trigger>
+                  <Collapsible.Content>
+                    <Navigator t={this.state.t}
+                               transcripts={this.props.transcripts}
+                               updateTime={this.updateTime.bind(this)}
+                               structures={structures}
+                    />
+                  </Collapsible.Content>
+                </Collapsible.Root>
+              )
+            } else {
+              return (
+                <Navigator t={this.state.t}
+                           transcripts={this.props.transcripts}
+                           updateTime={this.updateTime.bind(this)}
+                           structures={structures}
+                />
+              )
+            }
+          }}
+        </MediaQuery>
+      </div>
     )
   }
 }

--- a/src/components/canopy/Viewer.js
+++ b/src/components/canopy/Viewer.js
@@ -56,8 +56,9 @@ class Viewer extends Component {
             if (matches) {
               return (
                 <Collapsible.Root defaultOpen={false}>
-                  <Collapsible.Trigger>
-                    Expand
+                  <Collapsible.Trigger  id="canopy-collapse-trigger-navigator"
+                                        className="canopy-collapse-trigger">
+                    <span>Show Active Context</span>
                   </Collapsible.Trigger>
                   <Collapsible.Content>
                     <Navigator t={this.state.t}

--- a/src/sass/canopy.scss
+++ b/src/sass/canopy.scss
@@ -9,6 +9,7 @@
 // components
 @import "components/about";
 @import "components/button";
+@import "components/collapse";
 @import "components/control";
 @import "components/link";
 @import "components/search";

--- a/src/sass/components/_collapse.scss
+++ b/src/sass/components/_collapse.scss
@@ -18,8 +18,7 @@
     height: 36px;
     right: 0;
     padding: 0;
-    border-left: 1px solid $muted;
-    background-color: white;
+    background-color: red;
     box-shadow: none;
 
     span {

--- a/src/sass/components/_collapse.scss
+++ b/src/sass/components/_collapse.scss
@@ -1,0 +1,29 @@
+.canopy-collapse-trigger {
+  border: none;
+  background-color: $secondary;
+  padding: 1rem;
+  width: 100%;
+  font-family: $sans;
+  color: white;
+  font-weight: 700;
+  font-size: 0.8333em;
+  cursor: pointer;
+  box-shadow: $box-shadow;
+  position: relative;
+  z-index: 1;
+
+  &[data-state="open"] {
+    position: absolute;
+    width: 36px;
+    height: 36px;
+    right: 0;
+    padding: 0;
+    border-left: 1px solid $muted;
+    background-color: white;
+    box-shadow: none;
+
+    span {
+      display: none;
+    }
+  }
+}

--- a/src/sass/components/_collapse.scss
+++ b/src/sass/components/_collapse.scss
@@ -1,16 +1,21 @@
 .canopy-collapse-trigger {
   border: none;
-  background-color: $secondary;
   padding: 1rem;
   width: 100%;
   font-family: $sans;
   color: white;
+  background-color: $primary;
   font-weight: 700;
   font-size: 0.8333em;
   cursor: pointer;
-  box-shadow: $box-shadow;
   position: relative;
   z-index: 1;
+  display: flex;
+  justify-content: center;
+
+  svg {
+    display: none;
+  }
 
   &[data-state="open"] {
     position: absolute;
@@ -18,11 +23,17 @@
     height: 36px;
     right: 0;
     padding: 0;
-    background-color: red;
+    background-color: white;
     box-shadow: none;
+    border-left: 1px solid $muted;
 
     span {
       display: none;
+    }
+
+    svg {
+      display: block;
+      fill: $primary;
     }
   }
 }

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -19,6 +19,10 @@
     border-bottom: 1px solid $muted;
     color: $primary;
 
+    @include breakpoints(sm) {
+      font-size: 0.7222em;
+    }
+
     &:hover {
       background-color: $muted;
     }
@@ -40,6 +44,10 @@
       font-weight: 700;
       margin-top: 0.25em;
       margin-left: 2em;
+
+      @include breakpoints(sm) {
+        margin-top: 0.125em;
+      }
     }
 
     em {

--- a/src/sass/components/_viewer.scss
+++ b/src/sass/components/_viewer.scss
@@ -19,7 +19,7 @@
       width: 50%;
     }
 
-    @include breakpoints(xs) {
+    @include breakpoints(xxs, xs) {
       width: 100%;
     }
 
@@ -89,8 +89,12 @@
     }
 
     @include breakpoints(xs) {
+      height: 300px;
       width: 100%;
-      height: 500px;
+    }
+
+    @include breakpoints(xxs) {
+      width: 100%;
     }
   }
 }

--- a/src/sass/components/_viewer.scss
+++ b/src/sass/components/_viewer.scss
@@ -89,7 +89,6 @@
     }
 
     @include breakpoints(xs) {
-      height: 300px;
       width: 100%;
     }
 

--- a/src/sass/components/_viewer.scss
+++ b/src/sass/components/_viewer.scss
@@ -91,7 +91,7 @@
 
     @include breakpoints(xs) {
       width: 100%;
-      height: 400px; // temp fixed height
+      height: 500px;
     }
   }
 }

--- a/src/sass/components/_viewer.scss
+++ b/src/sass/components/_viewer.scss
@@ -3,7 +3,7 @@
   height: calc(100% - 1rem);
   background-color: white;
 
-  @include breakpoints(xs, sm) {
+  @include breakpoints(xs) {
     flex-direction: column;
   }
 
@@ -16,7 +16,11 @@
     box-shadow: $box-shadow-focus;
     z-index: 1;
 
-    @include breakpoints(xs, sm) {
+    @include breakpoints(sm) {
+      width: 50%;
+    }
+
+    @include breakpoints(xs) {
       width: 100%;
     }
 
@@ -81,7 +85,11 @@
     flex-shrink: 0;
     background-color: transparent;
 
-    @include breakpoints(xs, sm) {
+    @include breakpoints(sm) {
+      width: 50%;
+    }
+
+    @include breakpoints(xs) {
       width: 100%;
       height: 400px; // temp fixed height
     }

--- a/src/sass/components/_viewer.scss
+++ b/src/sass/components/_viewer.scss
@@ -13,7 +13,6 @@
     flex-shrink: 1;
     width: 61.8%;
     background-color: $primary;
-    box-shadow: $box-shadow-focus;
     z-index: 1;
 
     @include breakpoints(sm) {

--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -1,6 +1,10 @@
 header.canopy-header {
   padding: 1rem 2rem;
 
+  @include breakpoints(xs) {
+    padding: 1rem;
+  }
+
   a,
   a:visited {
     text-decoration: none !important;

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -9,13 +9,49 @@ article.canopy-manifest {
     margin: 0;
   }
 
+  &[data-mobile-navigator="true"] {
+    @include breakpoints(xs) {
+      header {
+        height: 0;
+        overflow: hidden;
+      }
+
+      .canopy-sticky > div {
+        transform: none !important;
+      }
+
+      .canopy-viewer {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: white;
+        overflow: hidden;
+
+        .canopy-video {
+          flex-grow: 0;
+        }
+
+        > div:last-child {
+          flex-grow: 1;
+
+          .canopy-sequence {
+            position: fixed;
+          }
+        }
+      }
+    }
+  }
+
   @extend .canopy-panel;
 
   header {
-    padding: 1rem;
     display: flex;
     justify-content: space-between;
     background-color: white;
+    height: 60px;
+    transition: all 200ms ease-in-out;
 
     h1 {
       margin: 0;
@@ -25,6 +61,7 @@ article.canopy-manifest {
       letter-spacing: -0.02em;
       padding-right: 5rem;
       font-family: $serif;
+      padding: 1rem;
 
       @include breakpoints(xs) {
         white-space: nowrap;

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -52,29 +52,46 @@ article.canopy-manifest {
     background-color: white;
     transition: all 200ms ease-in-out;
 
+    @include breakpoints(xs) {
+      flex-direction: column-reverse;
+    }
+
     h1 {
       margin: 0;
       font-size: 1.5em;
       font-weight: 400;
       line-height: 1.25em;
       letter-spacing: -0.02em;
-      padding-right: 5rem;
+      padding-right: 3rem;
       font-family: $serif;
       padding: 1rem;
 
       @include breakpoints(xs, sm) {
         font-size: 1.25em;
+        padding: 1.25rem 1rem;
+      }
+
+      @include breakpoints(xs) {
+        padding: 0 1rem 1rem;
+        text-align: center;
       }
     }
 
     > div {
       display: flex;
+      padding: 1rem;
+      align-items: flex-start;
+
+      @include breakpoints(xs) {
+        justify-content: center;
+      }
 
       > * {
         margin-right: 1.5em;
 
         &:last-child {
           margin-right: 0;
+          white-space: nowrap;
         }
       }
 

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -50,7 +50,6 @@ article.canopy-manifest {
     display: flex;
     justify-content: space-between;
     background-color: white;
-    height: 60px;
     transition: all 200ms ease-in-out;
 
     h1 {
@@ -63,14 +62,8 @@ article.canopy-manifest {
       font-family: $serif;
       padding: 1rem;
 
-      @include breakpoints(xs) {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+      @include breakpoints(xs, sm) {
         font-size: 1.25em;
-        white-space: nowrap;
-        width: 50%;
-        flex-grow: 0;
       }
     }
 

--- a/src/sass/layout/_manifest.scss
+++ b/src/sass/layout/_manifest.scss
@@ -5,6 +5,10 @@ article.canopy-manifest {
   background-color: transparent;
   box-shadow: $box-shadow;
 
+  @include breakpoints(xs) {
+    margin: 0;
+  }
+
   @extend .canopy-panel;
 
   header {
@@ -21,6 +25,16 @@ article.canopy-manifest {
       letter-spacing: -0.02em;
       padding-right: 5rem;
       font-family: $serif;
+
+      @include breakpoints(xs) {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 1.25em;
+        white-space: nowrap;
+        width: 50%;
+        flex-grow: 0;
+      }
     }
 
     > div {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,6 +3403,11 @@ body-parser@1.19.0, body-parser@^1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+body-scroll-lock@^4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
+  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,6 +1647,22 @@
     "@radix-ui/react-polymorphic" "0.0.12"
     "@radix-ui/react-primitive" "0.0.14"
 
+"@radix-ui/react-collapsible@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-0.0.17.tgz#d778ec1d5b7b4543fd4db1b3e4be96c74568d441"
+  integrity sha512-MiRf6eTNXBIEhOOK7F2kEJy6atr26PLVAT3gTONUvGTMPT2fUVZTOrG/KfnTyOuUoL4W468UPwTD1xN2L9tbUw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.0.5"
+    "@radix-ui/react-compose-refs" "0.0.5"
+    "@radix-ui/react-context" "0.0.5"
+    "@radix-ui/react-id" "0.0.6"
+    "@radix-ui/react-polymorphic" "0.0.13"
+    "@radix-ui/react-presence" "0.0.15"
+    "@radix-ui/react-primitive" "0.0.15"
+    "@radix-ui/react-use-controllable-state" "0.0.6"
+    "@radix-ui/react-use-layout-effect" "0.0.5"
+
 "@radix-ui/react-collection@0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-0.0.14.tgz#c51c790100407e8eb38be2b67538a5ff7c52915e"
@@ -4371,6 +4387,11 @@ css-loader@^5.0.1:
     postcss-value-parser "^4.1.0"
     schema-utils "^3.0.0"
     semver "^7.3.5"
+
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
 
 css-minimizer-webpack-plugin@^2.0.0:
   version "2.0.0"
@@ -7477,6 +7498,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -8943,6 +8969,13 @@ markdown-table@^2.0.0:
   integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
   dependencies:
     repeat-string "^1.0.0"
+
+matchmediaquery@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.1.tgz#8247edc47e499ebb7c58f62a9ff9ccf5b815c6d7"
+  integrity sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 md5-file@^5.0.0:
   version "5.0.0"
@@ -11176,6 +11209,16 @@ react-remove-scroll@^2.4.0:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
+react-responsive@^9.0.0-beta.3:
+  version "9.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.3.tgz#934cd8e21d007335ef1456b66288ee197e69b78a"
+  integrity sha512-h194vQjUvxY4f9pMWDltSqllymir6Kdt5bqmTOdBeHsVnk/oe+lmD296hViKUDSYfjAHhdKVHMiexYY9dmvA+w==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
+    shallow-equal "^1.2.1"
+
 react-side-effect@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
@@ -12007,6 +12050,11 @@ shallow-compare@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/shallow-compare/-/shallow-compare-1.2.2.tgz#fa4794627bf455a47c4f56881d8a6132d581ffdb"
   integrity sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg==
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 sharp@^0.28.0, sharp@^0.28.1:
   version "0.28.3"


### PR DESCRIPTION
https://jirautk.atlassian.net/browse/DIGITAL-1207

# What Does This Do

This pull request makes all elements in the `<Viewer/>` component fully responsive. Due to its adjacency it also extends responsive styling to the `<DigitalObjectHeader/>`. This was completed using a combination of helpful React packages for responsiveness and scroll locking. An additional Radix UI component `Collapsible` was used to aid in the display of navigator content on mobile viewports.

Responsive behavior is as follow:
- On Desktop view, the `<Navigator/>` taking 38.2% will be the right aside of the `<Video/>` taking 61.8% (golden ratio)/
![image](https://user-images.githubusercontent.com/7376450/130667829-2f9592e6-19e7-41a5-b4a2-8e25f3dd836e.png)

- As the page contracts to 1024px, the `<Navigator/>` and `<Video/>` will share 50% width respectively
![image](https://user-images.githubusercontent.com/7376450/130667894-e4d075cb-dcff-4915-9c6a-d572aa6572f2.png)

- At 800px wide, the `<Navigator/>` will slide under the `<Video/>` component with it's contents hidden in the Radix UI `Collapsible` component. A trigger button with the string **Show Active Context** will display by default. Underneath this, you will see the `<Details/>` component.
![image](https://user-images.githubusercontent.com/7376450/130668037-6b644e54-6d12-4b85-8b26-435cdbf34186.png)

- When **Show Active Context** is expanded, all other elements beside the viewer will slide away, and the `<Viewer/>` will become fixed to entire window. A user can then scroll through and interact with the `<Navigator/>` panels OR close the expanded `<Viewer/>`.
![image](https://user-images.githubusercontent.com/7376450/130668096-d4d21c19-f402-4ef2-a1bd-bb5187e370c1.png)

# How do I review
Visit the deploy preview https://deploy-preview-16--iiif-canopy.netlify.app/ and interact with it using your browser at all widths and heights. 

# Additional Notes
There still may be some usability issues existing. Tackling any of these might be best completed in micro issues.




