### PR TITLE
Address DIGITAL-1324: remove dl link from Chrome.

### DIFF
--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -8,11 +8,11 @@ const accompanyingCanvas = {
   "type": "Canvas",
   "label": {
     "en": [
-      "First page of score for Gustav Mahler, Symphony No. 3"
+      "Accompanying Canvas for RFTA Audiofile"
     ]
   },
-  "height": 998,
-  "width": 772,
+  "height": 200,
+  "width": 134,
   "items": [
     {
       "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page",
@@ -23,11 +23,11 @@ const accompanyingCanvas = {
           "type": "Annotation",
           "motivation": "painting",
           "body": {
-            "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/!300,300/0/default.jpg",
+            "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~rfta%3A143~datastream~TN/full/134,200/0/default.jpg",
             "type": "Image",
             "format": "image/jpeg",
-            "height": 998,
-            "width": 772,
+            "height": 134,
+            "width": 200,
             "service": [
               {
                 "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -266,7 +266,8 @@ class Video extends Component {
                      ref={this.video}
                      onPlay={this.handlePlay}
                      onPause={this.handlePause}
-                     crossOrigin="anonymous">
+                     crossOrigin="anonymous"
+                     controlsList="nodownload">
                 {this.renderSource(source, format)}
                 {this.renderTracks(tracks)}
               </video>

--- a/src/components/canopy/Video.js
+++ b/src/components/canopy/Video.js
@@ -26,8 +26,8 @@ const accompanyingCanvas = {
             "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~rfta%3A143~datastream~TN/full/134,200/0/default.jpg",
             "type": "Image",
             "format": "image/jpeg",
-            "height": 134,
-            "width": 200,
+            "height": 200,
+            "width": 134,
             "service": [
               {
                 "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",


### PR DESCRIPTION
## What Does This Do

Removes the download link from the HTML 5 viewer.

## Why

The project team has requested that we move it

## How can I test

In Chrome, go to https://rfta.lib.utk.edu/search/object/seemona-and-daniel-whaley-2019-09-20

Click the three dots in the viewer.  You should see a download button.

Now, open the preview link and go to the same video.  You shouldn't see the download link.