### PR TITLE
Drop canonical tag.

### DIFF
--- a/src/components/layout/seo.js
+++ b/src/components/layout/seo.js
@@ -42,10 +42,6 @@ function Seo({ description, lang, meta, title }) {
             "type": "image/png",
             'sizes': '114x114',
             'href': 'https://brand.utk.edu/wp-content/themes/ut-thehill/images/interface/icon-114x114.png'
-          },
-          {
-            'rel': 'canonical',
-            'href': 'https://rfta.lib.utk.edu'
           }
         ]
       }


### PR DESCRIPTION
## What Does This Do

Removes the canonical metatag.

## Why

Currently, all the pages in our sitemap are known to Google but not getting indexed.  My belief is that this is due this tag.  It's appearing on all subpages and telling google that these pages are a duplicate of the index.