### PR TITLE
Address DIGITAL-1356 Chrome Video Bug.

### DIFF
--- a/src/components/canopy/Video/index.js
+++ b/src/components/canopy/Video/index.js
@@ -230,7 +230,6 @@ class Video extends Component {
                 crossOrigin="anonymous"
                 controlsList="nodownload"
               >
-                <track kind="captions" />
                 {this.renderSource(source, format)}
                 {this.renderTracks(tracks)}
               </video>


### PR DESCRIPTION
## What Does This Do

Fixes the problem with the video player in Chrome where a broken subtitle track is present as a closed captioning option.

## What's New?

For some reason, we had an extra track present in all audio and video objects.  It's not clear what the purpose of this was, but it was causing a bad track to be present in Chrome.  This track has been removed.

## How can I test?

Look at a Spanish language object in Chrome or Chromium like [this](https://deploy-preview-42--iiif-canopy.netlify.app/interviews/object/billy-henriquez-2021-03-11).  Can you navigate properly? Do tracks still work?

Similarly, review an English only object like [this](https://deploy-preview-42--iiif-canopy.netlify.app/interviews/object/alan-sheets-2019-11-09).  Can you turn captioning on and off?  Do they work?
