### PR TITLE
Start addressing DIGITAL-1369.

### DIFF
--- a/src/components/canopy/SearchResult.js
+++ b/src/components/canopy/SearchResult.js
@@ -13,10 +13,9 @@ const SearchResult = ({ result }) => {
         </figure>
       </GatsbyLink>
       <div>
-        <a
-          href={slugWithSlash}>
+        <GatsbyLink to={slugWithSlash}>
           <header>{label || slug}</header>
-        </a>
+        </GatsbyLink>
         <p>{summary}</p>
       </div>
     </article>

--- a/src/components/canopy/SearchResult.js
+++ b/src/components/canopy/SearchResult.js
@@ -1,15 +1,17 @@
 import React from 'react'
+import { Link as GatsbyLink } from "gatsby"
 
 const SearchResult = ({ result }) => {
   const { label, slug, summary, thumbnail } = result
-  const slugWithSlash = slug.endsWith('/') ? slug : `${slug}/`;
+  console.log(slug);
+  let slugWithSlash = slug.endsWith('/') ? slug : `${slug}/`;
   return (
     <article key={slug}>
-      <a href={slugWithSlash} >
+      <GatsbyLink to={slugWithSlash}>
         <figure className='results-thumbnails'>
           <img src={thumbnail} alt={label} />
         </figure>
-      </a>
+      </GatsbyLink>
       <div>
         <a
           href={slugWithSlash}>

--- a/src/pages/interviews.js
+++ b/src/pages/interviews.js
@@ -16,7 +16,7 @@ const Search = ({ data, location }) => {
 
   return (
     <Layout location={location}>
-      <Seo title={title} canonical={nodeCanonical} />
+      <Seo title={title} canonical={`${nodeCanonical}/`} />
       <SearchLimits query={query} />
       <div className="canopy-main canopy-main-inner row px-0 mx-0">
         <div className="col-sm-4 px-0 mx-0 grey-background">


### PR DESCRIPTION
# What Does this Do

Fixes broken links when limiting in rfta.

# Does this have adverse affects?

Yes.  The link it seems that Gatsby forces into using is 301.  We are combatting this with canonical links and sitemap, but looking at this in SEO Spider or something like that is going to show a ton of 3xx redirects.