### PR TITLE
Address DIGITAL-1349.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ yarn-error.log
 .idea
 
 static/sample/local
+
+.netlify/*

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ const merge = require('lodash/merge');
 * Set root IIIF Collection conforming to specification
 * at https://iiif.io/api/presentation/3.0/#51-collection
 */
-const rootCollection = 'https://digital.lib.utk.edu/static/iiif/collections/rfta_completed.json';
+const rootCollection = 'https://digital.lib.utk.edu/static/iiif/collections/cdf_compliance.json';
 
 /*
 * Map nodes from IIIF Collection and Manifests
@@ -43,7 +43,7 @@ exports.sourceNodes = async ({actions, createNodeId, createContentDigest, graphq
 
     node.transcripts = ((items, transcripts = []) =>{
       if (Array.isArray(items)) {
-        items[0].items[0].items.map(function(element) {
+        items[0].annotations[0].items.map(function(element) {
           if (element.motivation === 'supplementing' && element.body.format === 'text/vtt') {
             transcripts.push(element.body)
           }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ const merge = require('lodash/merge');
 * Set root IIIF Collection conforming to specification
 * at https://iiif.io/api/presentation/3.0/#51-collection
 */
-const rootCollection = 'https://digital.lib.utk.edu/static/iiif/collections/cdf_compliance.json';
+const rootCollection = 'https://digital.lib.utk.edu/static/iiif/collections/rfta_completed.json';
 
 /*
 * Map nodes from IIIF Collection and Manifests

--- a/src/components/canopy/Video/index.js
+++ b/src/components/canopy/Video/index.js
@@ -57,6 +57,7 @@ class Video extends Component {
     if (Array.isArray(this.props.items)) {
 
       const items = this.props.items[0].items[0].items;
+      const annotations = this.props.items[0].annotations[0].items;
 
       items.forEach(function(element) {
         if (element.motivation === 'painting') {
@@ -64,24 +65,27 @@ class Video extends Component {
             source: element.body.id,
             format: element.body.format
           });
-        } else if (element.motivation === 'supplementing') {
-          let tracks = component.state.tracks
-          let track = {}
-          track.src = element.body.id
-          var label_for_dom = ''
-          if (element.body.label.en !== null) {
-            label_for_dom = element.body.label.en[0]
-          }
-          else if (element.body.label.es !== null) {
-            label_for_dom = element.body.label.es[0]
-          }
-          track.label = label_for_dom
-          track.srclang = element.body.language
-          tracks.push(track)
-          component.setState({
-            tracks: tracks
-          });
         }
+      });
+
+      annotations.forEach(function(element) {
+        let tracks = component.state.tracks
+        let track = {}
+        track.src = element.body.id
+        console.log(element.body.id);
+        var label_for_dom = ''
+        if (element.body.label.en !== null) {
+          label_for_dom = element.body.label.en[0]
+        }
+        else if (element.body.label.es !== null) {
+          label_for_dom = element.body.label.es[0]
+        }
+        track.label = label_for_dom
+        track.srclang = element.body.language
+        tracks.push(track)
+        component.setState({
+          tracks: tracks
+        });
       });
 
       if (accompanyingCanvas) {

--- a/src/templates/manifest.js
+++ b/src/templates/manifest.js
@@ -137,9 +137,17 @@ export const manifestQuery = graphql`
               items {
                 motivation
                 body {
+                  id
+                  format
+                }
+              }
+            }
+            annotations {
+              items {
+                motivation
+                body {
                   label {
                     en
-                    es
                   }
                   language
                   id
@@ -188,7 +196,6 @@ export const manifestQuery = graphql`
             type
             label {
               en
-              es
             }
           }
         }

--- a/src/templates/manifest.js
+++ b/src/templates/manifest.js
@@ -148,6 +148,7 @@ export const manifestQuery = graphql`
                 body {
                   label {
                     en
+                    es
                   }
                   language
                   id
@@ -196,6 +197,7 @@ export const manifestQuery = graphql`
             type
             label {
               en
+              es
             }
           }
         }


### PR DESCRIPTION
# What Does This Do

This brings Canopy in line with [IIIF Recipe 219: Using Caption Files on Videos](https://iiif.io/api/cookbook/recipe/0219-using-caption-file/).

# Why are we doing this?

To do RFTA Artists, we are planning to use Clover for viewer. Clover expects valid manifests to be modeled.  Right now, our audio and videos are out of spec because the caption file is in the `items` property of the `Canvas`.  This isn't allowed because they have a `motivation` of `supplementing`.  This requires them to be in the `annotations` property of the canvas. In order to fix this upstream, we have to make sure Canopy isn't affected by this change for RFTA.

# What needs to happen prior to merge

- [x] Review the preview which cherry picks some objects for testing. Are things working as expected.
- [x] Make sure decisions regarding all IIIF assemble pull requests have been made and merged. (Especially: https://github.com/utkdigitalinitiatives/iiif_assemble/pull/32)
- [x] Switch `https://digital.lib.utk.edu/static/iiif/collections/cdf_compliance.json` to `https://digital.lib.utk.edu/static/iiif/collections/rfta_completed.json`
- [x] Add `es` back for Graphql schema definitions.

